### PR TITLE
mutating 'state' along with 'status' on order when creditmemo

### DIFF
--- a/app/code/local/Gracious/Pubsub/Model/Observer.php
+++ b/app/code/local/Gracious/Pubsub/Model/Observer.php
@@ -64,7 +64,7 @@ class Gracious_Pubsub_Model_Observer
         // Cloning the order, don't want to mutate the system's Order object.
         $order = clone $observer->getEvent()->getCreditmemo()->getOrder();
         $data = $order->getData();
-        $data["status"] = "closed";
+        $data['status'] = 'closed';
         $order->setData($data);
         $this->publish($order);
     }

--- a/app/code/local/Gracious/Pubsub/Model/Observer.php
+++ b/app/code/local/Gracious/Pubsub/Model/Observer.php
@@ -64,6 +64,7 @@ class Gracious_Pubsub_Model_Observer
         // Cloning the order, don't want to mutate the system's Order object.
         $order = clone $observer->getEvent()->getCreditmemo()->getOrder();
         $data = $order->getData();
+        $data['state'] = 'closed';
         $data['status'] = 'closed';
         $order->setData($data);
         $this->publish($order);


### PR DESCRIPTION
The `sales_order_creditmemo_refund` event invokes its observer method before the actual order `state` and `status` is being altered. As a workaround we change the `state` and `status` to yield the value closed ourselfs before it gets sent to pubsub.